### PR TITLE
Updated broken link to batch destinations tutorial

### DIFF
--- a/help/platform/destinations/configuring-file-based-cloud-storage-or-email-marketing-destinations.md
+++ b/help/platform/destinations/configuring-file-based-cloud-storage-or-email-marketing-destinations.md
@@ -10,7 +10,9 @@ exl-id: fda985ad-5d56-4e61-871f-2f29a2e79b17
 ---
 # Configuring file-based [!UICONTROL cloud storage] or [!UICONTROL email marketing] destinations
 
-Get tips during a walkthrough of the configuration of a file-based destination in Adobe's Real-time Customer Data Platform (CDP). This applies to [!UICONTROL cloud storage] destinations (E.g. S3 or SFTP) and also [!UICONTROL email marketing] destinations. For more detailed product documentation, see [connect to email marketing destinations and activate data](https://experienceleague.adobe.com/docs/experience-platform/rtcdp/destinations/api-tutorials/email-marketing-api.html)
+Get tips during a walkthrough of the configuration of a file-based destination in Adobe's Real-time Customer Data Platform (CDP). This applies to [!UICONTROL cloud storage] destinations (E.g. S3 or SFTP) and also [!UICONTROL email marketing] destinations. For more detailed product documentation, see:
+
+* [Activate audience data to batch profile export destinations](https://experienceleague.adobe.com/docs/experience-platform/destinations/ui/activate/activate-batch-profile-destinations.html) for instructions on how to activate data to batch or email marketing destinations using the Experience Platform UI
+* [Connect to batch destinations and activate data using the Flow Service API](https://experienceleague.adobe.com/docs/experience-platform/destinations/api/connect-activate-batch-destinations.html) for instructions on how to activate data to batch or email marketing destinations using the Flow Service API
 
 >[!VIDEO](https://video.tv.adobe.com/v/328175/?quality=12&learn=on)
-


### PR DESCRIPTION
As part of my work for [PLAT-108997](https://jira.corp.adobe.com/browse/PLAT-108997), I updated the link of an API tutorial in the experience-platform documentation repository. 

With this PR, I am:
* updating the link to point to the new page
* editing a sentence to distinguish between the instructions on activating data to batch destinations using the Platform UI or the Flow Service API. 